### PR TITLE
Feature/thumbprint punctuation

### DIFF
--- a/Anar.Tests/Services/Gateway/GatewayOptionsTests.cs
+++ b/Anar.Tests/Services/Gateway/GatewayOptionsTests.cs
@@ -1,0 +1,20 @@
+namespace Anar.Services.Gateway;
+
+public class GatewayClientTests
+{
+    [Fact]
+    public void ThumbprintMutator_ReplacesNonHexDigits()
+    {
+        // Arrange
+        var options = new GatewayOptions
+        {
+            Thumbprint = "A1:b2:C3-d4-E5-f6-Gg-78-90",
+        };
+
+        // Act
+        var thumbprint = options.Thumbprint;
+
+        // Assert
+        Assert.Equal("A1b2C3d4E5f67890", thumbprint);
+    }
+}

--- a/Anar/Anar.csproj
+++ b/Anar/Anar.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Anar-e3577f76-ab06-4227-8831-6d6e7e2c7374</UserSecretsId>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Anar/Services/Gateway/ClientHandler.cs
+++ b/Anar/Services/Gateway/ClientHandler.cs
@@ -9,9 +9,12 @@ internal sealed class ClientHandler : HttpClientHandler
 {
     private readonly IOptions<GatewayOptions> _options;
 
-    public ClientHandler(IOptions<GatewayOptions> options)
+    private readonly ILogger _logger;
+
+    public ClientHandler(IOptions<GatewayOptions> options, ILogger<ClientHandler> logger)
     {
         _options = options;
+        _logger = logger;
         ServerCertificateCustomValidationCallback = ValidateThumbprint;
     }
 
@@ -28,7 +31,27 @@ internal sealed class ClientHandler : HttpClientHandler
         HttpRequestMessage message,
         X509Certificate2? cert,
         X509Chain? chain,
-        SslPolicyErrors errors
-    ) => errors == SslPolicyErrors.None
-      || _options.Value.Thumbprint == cert?.Thumbprint;
+        SslPolicyErrors errors)
+    {
+        if (errors == SslPolicyErrors.None)
+        {
+            return true;
+        }
+
+        if (_options.Value.Thumbprint.Equals(cert?.Thumbprint, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // Log a less cryptic error than SSL could not be established.
+        // Include actual in case it's the annual renew.
+        _logger.LogError(
+            "Invalid Thumbprint: Expected {Expected}, Actual {Actual}",
+            _options.Value.Thumbprint,
+            cert?.Thumbprint
+        );
+
+        return false;
+    }
+
 }

--- a/Anar/Services/Gateway/Gateway.cs
+++ b/Anar/Services/Gateway/Gateway.cs
@@ -24,7 +24,6 @@ internal interface IGateway
 /// <param name="logger"></param>
 internal sealed class Gateway : IGateway
 {
-    const string Path = "api/v1/production/inverters";
     private readonly HttpClient _httpClient;
 
     private readonly IOptions<GatewayOptions> _options;

--- a/Anar/Services/Gateway/GatewayOptions.cs
+++ b/Anar/Services/Gateway/GatewayOptions.cs
@@ -1,15 +1,31 @@
 // spell-checker: words Enphase
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 
 namespace Anar.Services.Gateway;
 
-internal sealed class GatewayOptions
+internal sealed partial class GatewayOptions
 {
+    [ExcludeFromCodeCoverage]
+    [GeneratedRegex("[^0-9A-F]", RegexOptions.IgnoreCase, "en-US")]
+    public static partial Regex NonHexDigitsRegex();
+
+    /// <summary>
+    /// Backing store for Thumbprint property.
+    /// </summary>
+    private string _thumbprint = string.Empty;
+
     /// <summary>
     /// Thumbprint of the self-signed certificate in the gateway.
     /// </summary>
     [Required]
-    public string Thumbprint { get; init; } = string.Empty;
+    public string Thumbprint
+    {
+        get => _thumbprint;
+        // Allow thumbprint to contain punctuation AB:CD:EF
+        init => _thumbprint = NonHexDigitsRegex().Replace(value, string.Empty);
+    }
 
     /// <summary>
     /// Path to the endpoint on the gateway.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Enphase does not make direct access easy.
 ### Gateway : Thumbprint (string)
 This is the SHA-1 value of the self-signed certificate of your Enphase gateway.
 You can capture this by reviewing browser security settings.  Value is a stream
-of hex digits with no punctuation.
+of hex digits. Colons or Dashes between characters (AB:CD:EF) will be ignored.
 
 ### Gateway : Token (string)
 This is the security token the system should use when accessing your gateway.


### PR DESCRIPTION
Allow colon or dash in Gateway:Thumbprint setting for easier copy/paste.